### PR TITLE
feat: #40 — accesso schermata rimborsi + fix reimbursed_at

### DIFF
--- a/lib/features/expenses/data/datasources/expense_remote_datasource.dart
+++ b/lib/features/expenses/data/datasources/expense_remote_datasource.dart
@@ -391,7 +391,15 @@ class ExpenseRemoteDataSourceImpl implements ExpenseRemoteDataSource {
       }
       if (merchant != null) updates['merchant'] = merchant;
       if (notes != null) updates['notes'] = notes;
-      if (reimbursementStatus != null) updates['reimbursement_status'] = reimbursementStatus.value; // T048
+      if (reimbursementStatus != null) {
+        updates['reimbursement_status'] = reimbursementStatus.value; // T048
+        // Set reimbursed_at when marking as reimbursed; clear it otherwise
+        if (reimbursementStatus == ReimbursementStatus.reimbursed) {
+          updates['reimbursed_at'] = DateTime.now().toUtc().toIso8601String();
+        } else {
+          updates['reimbursed_at'] = null;
+        }
+      }
       if (reimbursableToLabel != null) updates['reimbursable_to_label'] = reimbursableToLabel;
       if (reimbursableToUserId != null) updates['reimbursable_to_user_id'] = reimbursableToUserId;
       if (reimbursableAmount != null) updates['reimbursable_amount'] = reimbursableAmount;

--- a/lib/features/expenses/presentation/screens/expense_tabs_screen.dart
+++ b/lib/features/expenses/presentation/screens/expense_tabs_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../../app/routes.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../auth/presentation/providers/auth_provider.dart';
 import '../../../categories/presentation/widgets/category_dropdown.dart';
@@ -77,6 +79,11 @@ class _ExpenseTabsScreenState extends ConsumerState<ExpenseTabsScreen> {
             icon: const Icon(Icons.filter_alt_outlined),
             onPressed: () => _showFilterDialog(context),
             tooltip: 'Filtra',
+          ),
+          IconButton(
+            icon: const Icon(Icons.account_balance_wallet_outlined),
+            onPressed: () => context.push(AppRoutes.reimbursements),
+            tooltip: 'Rimborsi',
           ),
         ],
       ),


### PR DESCRIPTION
# 💰 Issue #40: Schermata Rimborsi Accessibile + Fix Flusso

## T9 — Schermata Rimborsi Accessibile
- Aggiunto IconButton (💰 wallet) nell'AppBar di 'Le mie spese'
- Tap → naviga a `/reimbursements`
- File: `expense_tabs_screen.dart`

## T10 — Bug Fix: reimbursed_at non salvato
- **Bug:** Quando si segnava una spesa come 'Rimborsato', il campo `reimbursed_at` non veniva mai scritto nel DB
- **Fix:** Ora imposta `reimbursed_at = DateTime.now().toUtc()` quando status → `reimbursed`
- File: `expense_remote_datasource.dart`

## Flusso Verificato
- ✅ Lista 'Da rimborsare' carica correttamente
- ✅ markAsReimbursed funziona (reimbursable → reimbursed)
- ✅ reimbursement_confirmed_by settato
- ✅ reimbursed_at ora salvato correttamente
- ✅ Totali si aggiornano via Riverpod

## File Modificati
1. `lib/features/expenses/presentation/screens/expense_tabs_screen.dart` — IconButton AppBar
2. `lib/features/expenses/data/datasources/expense_remote_datasource.dart` — Fix reimbursed_at

Closes #40